### PR TITLE
Bugfix for orpheaned node

### DIFF
--- a/src/lib/rangy-extensions.js
+++ b/src/lib/rangy-extensions.js
@@ -113,7 +113,8 @@ rangy.api.createCoreModule('RangyExtensions', [], function(api) {
     // DOM extensions
     //
     api.dom.hasParents = function(node, parents) {
-        while ([document, document.body].indexOf(node) === -1) {
+        // node may be inside a documentFragment outside document, so we should also test null
+        while ([ document, document.body ].indexOf(node) === -1 && node != null) {
             if (parents.indexOf(node) !== -1) {
                 return true;
             }


### PR DESCRIPTION
I sometime get an error inside JS console, the `api.dom.hasParents` function fails because of some node outside the document. This seems the fix the bug.
