### PR TITLE
Minimal RTL support

### DIFF
--- a/src/css/editor.styl
+++ b/src/css/editor.styl
@@ -103,6 +103,14 @@ editor-input-fgcolor ?= #000
     &.{editor-class-prefix}menu span.{editor-class-prefix}menu-arrow
         color lighten(editor-fgcolor, -50%)
 
+.{editor-class-prefix}controls.rtl li,
+html[dir='rtl'] .{editor-class-prefix}controls li
+    float right
+
+    li button
+        text-align right
+
+
 .{editor-class-prefix}dialog
     padding 6px
     font-size 12px

--- a/src/lib/controls.js
+++ b/src/lib/controls.js
@@ -77,14 +77,14 @@ var BaseControl = Class(Object, {
         }
 
         var text = document.createTextNode(label);
+        var span = document.createElement('span');
+        span.appendChild(text);
         if (this.toolbar.options.fontAwesomeEnabled && fontAwesomeID) {
             var fa = this.getFaElement(fontAwesomeID);
-            var span = document.createElement('span');
-            span.appendChild(text);
             fa.appendChild(span);
             this.element.appendChild(fa);
         } else {
-            this.element.appendChild(text);
+            this.element.appendChild(span);
         }
     },
 

--- a/src/lib/editor.js
+++ b/src/lib/editor.js
@@ -13,10 +13,11 @@ var HtmlCleaner = require('./html-cleaner').HtmlCleaner;
 var Editor = Class(Object, {
     defaults: {
         delay: 300,
-        diffLeft: 2,
-        diffTop: -10,
+        offsetX: 2,
+        offsetY: -10,
         classPrefix: 'editor-',
-        fontAwesomeEnabled: true
+        fontAwesomeEnabled: true,
+        rtl: false
     },
     BLOCK_NODES: 'P H1 H2 H3 H4 H5 H6 UL OL PRE DL DIV NOSCRIPT BLOCKQUOTE FORM HR TABLE FIELDSET ADDRESS'.split(' '),
 
@@ -37,6 +38,7 @@ var Editor = Class(Object, {
         this.isActive = true;
         this.isSelected = false;
         this.options = extend({}, this.defaults, options);
+        this.isRtl = this.options.rtl || document.documentElement.getAttribute('dir') === 'rtl';
 
         // Internal properties
         this._currentEditor = null;
@@ -193,16 +195,18 @@ var Editor = Class(Object, {
         // Top position
         var top = 0;
         if (boundary.top < height) {
-            top = boundary.bottom - this.options.diffTop + window.pageYOffset;
+            top = boundary.bottom - this.options.offsetY + window.pageYOffset;
         } else {
-            top = boundary.top + this.options.diffTop + window.pageYOffset - height;
+            top = boundary.top + this.options.offsetY + window.pageYOffset - height;
         }
 
         // Left position
-        var left = boundary.left - this.options.diffLeft;
-        if (this._currentEditor.offsetWidth < width + boundary.left) {
-            left = boundary.right - width + this.options.diffLeft;
-        }
+        var left = boundary.left - this.options.offsetX,
+            right = boundary.right - width + this.options.offsetX,
+            overflowLeft = boundary.right - width < this._currentEditor.offsetLeft,
+            overflowRight = this._currentEditor.offsetLeft + this._currentEditor.offsetWidth < width + boundary.left;
+
+        if ((this.isRtl && !overflowLeft) || overflowRight) left = right;
 
         this.toolbar.move(top, left);
     },

--- a/src/lib/toolbar.js
+++ b/src/lib/toolbar.js
@@ -23,6 +23,7 @@ var Toolbar = Class(Object, {
         this.dialog = document.createElement('div');
 
         this.container.classList.add(this._getClassName('controls'));
+        if (this.editor.isRtl) this.container.classList.add('rtl');
         this.element.classList.add(this._getClassName('toolbar'));
         document.body.appendChild(this.element);
 


### PR DESCRIPTION
This PR adapts the toolbar alignment behaviour when in RTL mode (for example for Arabic).

It can be set with a new `rtl` option (that defaults to false), plus it's automatic if `dir='rtl'` is set on the `html` node.

I've also renamed `diffLeft` and `diffTop` to `offsetX` and `offsetY` because I though that was more conventional naming for such values, but of course this change it not needed for the PR, so if you disagree with it I'll revert it. Also, given that minislate is not announced as stable we can tolerate such break of the API.
