### PR TITLE
Add basic i18n support

### DIFF
--- a/src/lib/controls/block.js
+++ b/src/lib/controls/block.js
@@ -8,6 +8,7 @@ var _util = require('../util'),
     Class = _util.Class,
     extend = _util.extend,
     _ = _util._,
+    tr = _util.tr,
     Button = _controls.Button;
 
 
@@ -59,7 +60,7 @@ exports.Paragraph = Class(Block, {
     command: 'formatblock',
     defaults: extend({}, Block.prototype.defaults, {
         label: '¶',
-        title: 'Paragraph'
+        title: tr('Paragraph')
     })
 });
 
@@ -70,7 +71,7 @@ for (var i=1; i<=6; i++) {
         tag: 'h' + i,
         defaults: extend({}, Block.prototype.defaults, {
             label: 'H' + i,
-            title: 'Title level ' + i
+            title: tr('Title level {level}', {level: i})
         })
     });
     exports['H' + i] = C;
@@ -83,7 +84,7 @@ exports.Preformated = Class(Block, {
     tag: 'pre',
     defaults: extend({}, Block.prototype.defaults, {
         label: '<>',
-        title: 'Code',
+        title: tr('Code'),
         fontAwesomeID: 'code',
         tabReplacement: '    '
     }),
@@ -176,7 +177,7 @@ exports.UnorderedList = Class(BaseList, {
     command: 'insertunorderedlist',
     defaults: extend({}, BaseList.prototype.defaults, {
         label: 'UL',
-        title: 'Unordered list',
+        title: tr('Unordered list'),
         fontAwesomeID: 'list-ul'
     })
 });
@@ -188,7 +189,7 @@ exports.OrderedList = Class(BaseList, {
     command: 'insertorderedlist',
     defaults: extend({}, BaseList.prototype.defaults, {
         label: 'OL',
-        title: 'Ordered list',
+        title: tr('Ordered list'),
         fontAwesomeID: 'list-ol'
     })
 });
@@ -199,7 +200,7 @@ exports.Blockquote = Class(Block, {
     tagList: ['blockquote'],
     defaults: extend({}, Block.prototype.defaults, {
         label: 'Quote',
-        title: 'Quote',
+        title: tr('Quote'),
         fontAwesomeID: 'quote-right'
     }),
 

--- a/src/lib/controls/inline.js
+++ b/src/lib/controls/inline.js
@@ -8,6 +8,7 @@ var _util = require('../util'),
     Class = _util.Class,
     extend = _util.extend,
     _ = _util._,
+    tr = _util.tr,
     Button = _controls.Button,
     Dialog = _controls.Dialog;
 
@@ -47,7 +48,7 @@ exports.Inline = Inline;
 exports.Bold = Class(Inline, {
     defaults: extend({}, Inline.prototype.defaults, {
         label: 'B',
-        title: 'Bold',
+        title: tr('Bold'),
         fontAwesomeID: 'bold'
     }),
     tagList: ['b', 'strong'],
@@ -73,7 +74,7 @@ exports.Bold = Class(Inline, {
 exports.Italic = Class(Inline, {
     defaults: extend({}, Inline.prototype.defaults, {
         label: 'I',
-        title: 'Italic',
+        title: tr('Italic'),
         fontAwesomeID: 'italic'
     }),
     tagList: ['i', 'em'],
@@ -99,7 +100,7 @@ exports.Italic = Class(Inline, {
 exports.Underline = Class(Inline, {
     defaults: extend({}, Inline.prototype.defaults, {
         label: 'U',
-        title: 'Underline',
+        title: tr('Underline'),
         fontAwesomeID: 'underline'
     }),
     tagList: ['u', 'ins'],
@@ -110,7 +111,7 @@ exports.Underline = Class(Inline, {
 exports.StrikeThrough = Class(Inline, {
     defaults: extend({}, Inline.prototype.defaults, {
         label: 'S',
-        title: 'Strike-Through',
+        title: tr('Strike-Through'),
         fontAwesomeID: 'strikethrough'
     }),
     tagList: ['strike', 'del'],
@@ -164,7 +165,7 @@ var LinkDialog = Class(Dialog, {
 exports.Link = Class(Button, {
     defaults: extend({}, Button.prototype.defaults, {
         label: '#',
-        base_title: 'Link',
+        base_title: tr('Link'),
         title: '',
         fontAwesomeID: 'link'
     }),

--- a/src/lib/controls/media.js
+++ b/src/lib/controls/media.js
@@ -8,6 +8,7 @@ var _util = require('../util'),
     Class = _util.Class,
     extend = _util.extend,
     Button = _controls.Button,
+    tr = _util.tr,
     Dialog = _controls.Dialog;
 
 
@@ -49,7 +50,7 @@ var ImageDialog = Class(Dialog, {
 exports.Image = Class(Button, {
     defaults: extend({}, Button.prototype.defaults, {
         label: 'IMG',
-        title: 'Image',
+        title: tr('Image'),
         fontAwesomeID: 'picture-o'
     }),
 
@@ -102,7 +103,7 @@ exports.Image = Class(Button, {
 exports.Oembed = Class(Button, {
     defaults: extend({}, Button.prototype.defaults, {
         label: 'Embeded',
-        title: 'Embeded content',
+        title: tr('Embeded content'),
         fontAwesomeID: 'youtube-play'
     }),
 

--- a/src/lib/editor.js
+++ b/src/lib/editor.js
@@ -5,6 +5,7 @@ var extend = require('./util').extend;
 var Class = require('./util').Class;
 var Toolbar = require('./toolbar').Toolbar;
 var _ = require('./util')._;
+var tr = require('./util').tr;
 var HtmlCleaner = require('./html-cleaner').HtmlCleaner;
 
 /*
@@ -37,6 +38,7 @@ var Editor = Class(Object, {
         this.isActive = true;
         this.isSelected = false;
         this.options = extend({}, this.defaults, options);
+        if (this.options.i18n) tr.register(this.options.i18n);
 
         // Internal properties
         this._currentEditor = null;

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -46,6 +46,34 @@ var Class = function(parent, proto) {
 };
 
 
+/* *********************** I18N  **************************/
+// Very simple translation management system.
+// Use tr('yourstring') when you deal with a string that needs to be
+// translatable.
+// If you have dynamic variables, you can use tr('Title level {level}', {level: 1})
+// Use tr.register({string: translation}) to populate the locale.
+var I18n = function (s, data) {
+    return new I18n.LazyString(s, data);
+};
+I18n.locale = {};
+I18n.register = function (locale) {
+    for (var k in locale) I18n.locale[k] = locale[k];
+};
+I18n.LazyString = function (s, data) {
+    this.s = s;
+    this.data = data || {};
+};
+I18n.LazyString.prototype.toString = function () {
+    return I18n.template(I18n.locale[this.s] || this.s, this.data);
+};
+I18n.template = function (str, data) {
+    return str.replace(/\{ *([\w_]+) *\}/g, function (s, k) {
+        return data[k] || '';
+    });
+};
+
+
+
 // Some array utilities from underscore.js
 var _ = {};
 /* jshint ignore:start */
@@ -93,3 +121,4 @@ _.filter = function(obj, predicate, context) {
 exports.extend = extend;
 exports.Class = Class;
 exports._ = _;
+exports.tr = I18n;

--- a/src/main.js
+++ b/src/main.js
@@ -12,6 +12,7 @@ require('./lib/rangy-extensions');
 
 // Utils
 exports.extend = require('./lib/util').extend;
+exports.tr = require('./lib/util').tr;
 exports.Class = require('./lib/util').Class;
 exports.HtmlCleaner = require('./lib/html-cleaner').HtmlCleaner;
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -199,4 +199,25 @@ window.addEventListener('DOMContentLoaded', function() {
         test.deepEqual(getSelection().getTopNodes(root), []);
         test.deepEqual(getSelection().getSurroundingNodes(), [].slice.call(root.childNodes));
     });
+
+    module('I18n');
+    test('should be set via register', function (test) {
+        Minislate.tr.register({'string': 'translated'});
+        test.equal(Minislate.tr('string'), 'translated');
+    });
+    test('should be lazy', function (test) {
+        var translated = Minislate.tr('string');
+        Minislate.tr.register({'string': 'chaîne'});
+        test.equal(translated, 'chaîne');
+    });
+    test('should allow variables', function (test) {
+        var translated = Minislate.tr('title level {level}', {level: '1'});
+        Minislate.tr.register({'title level {level}': 'titre niveau {level}'});
+        test.equal(translated, 'titre niveau 1');
+    });
+    test('should be set via editor options', function (test) {
+        var element = document.createElement('div');
+        new Minislate.simpleEditor(element, {i18n: {'string': 'from options'}});
+        test.equal(Minislate.tr('string'), 'from options');
+    });
 });


### PR DESCRIPTION
Very simple translation management system.

Use `tr('yourstring')` when you deal with a string that needs to be translatable.

If you have dynamic variables, you can use `tr('Title level {level}', {level: yourvar})`.

Use tr.register({string: translation}) to populate the locale.

A new editor option is added, `i18n`, which, when present, will be used to register new localized strings.

So to add localized strings, one would do something like:

```
new Minilslate.simpleEditor(element, {
    i18n: {
        'Paragraph': 'Paragraphe',
        'Title level {level}': 'Titre niveau {level}',
        …
    }
}
```
